### PR TITLE
Add shared event display component

### DIFF
--- a/frontend/src/core/components/events/EventDisplay.tsx
+++ b/frontend/src/core/components/events/EventDisplay.tsx
@@ -1,0 +1,43 @@
+import type { CalendarEvent, UpcomingEvent } from '@/core/types';
+
+interface EventDisplayProps {
+  event: CalendarEvent | UpcomingEvent;
+  variant?: 'compact' | 'full' | 'card';
+  showVirtualBadge?: boolean;
+}
+
+export function EventDisplay({ event, variant = 'compact', showVirtualBadge = true }: EventDisplayProps) {
+  const formatDate = (date: string) => {
+    return new Date(date).toLocaleDateString('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  const getDate = () => {
+    if ('startDate' in event) {
+      return event.startDate;
+    }
+    return event.date;
+  };
+
+  if (variant === 'compact') {
+    return (
+      <div className="border-l-4 border-dsa-red pl-4 py-3">
+        <h4 className="font-bold">{event.title}</h4>
+        <p className="text-sm text-dsa-black">{formatDate(getDate())}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border rounded p-4">
+      <h4 className="font-bold mb-2">{event.title}</h4>
+      <p className="text-sm text-dsa-black mb-2">{formatDate(getDate())}</p>
+      {showVirtualBadge && 'isVirtual' in event && event.isVirtual && (
+        <span className="text-xs text-blue-600">Virtual Event</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/core/components/events/index.ts
+++ b/frontend/src/core/components/events/index.ts
@@ -1,0 +1,1 @@
+export * from './EventDisplay';

--- a/frontend/src/core/types/index.ts
+++ b/frontend/src/core/types/index.ts
@@ -1,3 +1,32 @@
+export * from './pages';
+export * from './layout';
+export * from './api';
+export * from './components';
+export * from './hooks';
+
+export interface BaseEvent {
+  id: string;
+  title: string;
+  date: string;
+  location: string;
+  isVirtual?: boolean;
+}
+
+export type EventCategory = 'meeting' | 'action' | 'social' | 'education' | 'other';
+
+export interface CalendarEvent extends BaseEvent {
+  startDate: string;
+  endDate?: string;
+  category: EventCategory;
+}
+
+export interface UpcomingEvent {
+  title: string;
+  date: string;
+  location: string;
+  isVirtual?: boolean;
+}
+
 export interface Newsletter {
   id: string;
   title: string;
@@ -9,6 +38,6 @@ export interface Newsletter {
   };
   author?: { node: { name: string } };
   content?: string;
-  fullContentPath?: string; // you may already have this
-  htmlPath: string; // <-- new
+  fullContentPath?: string;
+  htmlPath: string;
 }

--- a/frontend/src/features/ud-ydsa/Page.tsx
+++ b/frontend/src/features/ud-ydsa/Page.tsx
@@ -7,6 +7,7 @@ import type {
   MeetingInfoSectionContent,
   UdYdsaPageContent,
 } from '@/core/types/pages/ud-ydsa';
+import { EventDisplay } from '@/core/components/events';
 
 type Props = UdYdsaPageContent;
 
@@ -100,19 +101,9 @@ function EventsSection({
       <div className="container-page">
         <h2 className="text-3xl font-bold mb-8">Upcoming Events</h2>
         <div className="space-y-4 mb-8">
-          {upcomingEvents?.map(
-            (
-              event: EventsSectionContent['upcomingEvents'][number],
-              index: number
-            ) => (
-              <div key={index} className="border-l-4 border-dsa-red pl-4 py-3">
-                <h3 className="font-bold text-lg">{event.title}</h3>
-                <p className="text-dsa-black">
-                  {event.date} at {event.time} • {event.location}
-                </p>
-              </div>
-            )
-          )}
+          {upcomingEvents?.map((event, index) => (
+            <EventDisplay key={index} event={event} />
+          ))}
         </div>
         <a href={viewAllLinkHref} className="text-dsa-red hover:underline">
           {viewAllLinkText}


### PR DESCRIPTION
## Summary
- add `EventDisplay` shared component
- consolidate reusable types in `src/core/types/index.ts`
- use `EventDisplay` for UD-YDSA upcoming events

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684aaaa2ddb083328178fbb14cd9fd41